### PR TITLE
Fix KeyError when removing a disabled config entry

### DIFF
--- a/custom_components/nax/__init__.py
+++ b/custom_components/nax/__init__.py
@@ -107,7 +107,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     _LOGGER.debug("Removing NAX config entry %s", entry.entry_id)
 
     # Safely get and remove the API client if it exists
-    api: DataEventManager = hass.data[DOMAIN].pop(entry.entry_id, None)
+    api: DataEventManager = hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
 
     if api is not None:
         await api.stop_monitoring()

--- a/custom_components/nax/manifest.json
+++ b/custom_components/nax/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nax",
   "name": "NAX",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "integration_type": "device",
   "config_flow": true,
   "documentation": "https://github.com/jetsoncontrols/ha-nax",


### PR DESCRIPTION
hass.data[DOMAIN] may not exist if the entry was never loaded or already unloaded. Use .get() to avoid the KeyError on removal.